### PR TITLE
Nested bug issue #17

### DIFF
--- a/server/controllers/menu.js
+++ b/server/controllers/menu.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { get, isEmpty } = require( 'lodash' );
+const { get, has, isEmpty } = require( 'lodash' );
 const { ValidationError } = require( '@strapi/utils' ).errors;
 
 const { getService, serializeNestedMenu } = require( '../utils' );
@@ -13,7 +13,7 @@ module.exports = {
   },
 
   async find( ctx ) {
-    const nested = get( ctx.request.query, 'nested' ) !== 'false';
+    const nested = has( ctx.request.query, 'nested' );
     const populate = get( ctx.request.query, 'populate' ) !== 'false';
 
     let menus = await getService( 'menu' ).getMenus( populate );
@@ -28,7 +28,7 @@ module.exports = {
 
   async findOne( ctx ) {
     const { slug } = ctx.request.params;
-    const nested = get( ctx.request.query, 'nested' ) !== 'false';
+    const nested = has( ctx.request.query, 'nested' );
 
     let menu = await getService( 'menu' ).getMenu( slug, 'slug' );
 


### PR DESCRIPTION
This PR addresses a bug (I believe) where all responses coming back are nested whether or not the flag is set in the request query.

New behavior shows a flattened array with no nesting when ?nested is not set.  When ?nested is set it puts your menu through your `serializeNestedMenu` method.