### PR TITLE
Deep population for MenuItem relations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-menus",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A plugin for Strapi CMS to customize the structure of menus and menu items.",
   "license": "MIT",
   "strapi": {


### PR DESCRIPTION
This PR adds one extra level of population for `MenuItems`. In a future release, this feature will be refactored and possibly moved into the plugin config for the developer to configure on their own.