### PR TITLE
Fix description rendering in SelectOne and SelectMany

### DIFF
--- a/admin/src/components/FormLayout/index.js
+++ b/admin/src/components/FormLayout/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
 import { get } from 'lodash';
 
 import { GenericInput, useLibrary } from '@strapi/helper-plugin';
@@ -17,6 +18,7 @@ const FormLayout = ( { fields, gap } ) => {
     modifiedData,
     schema,
   } = useMenuData();
+  const { formatMessage } = useIntl();
 
   const getFieldName = name => {
     if ( name.indexOf( '.' ) !== -1 ) {
@@ -79,6 +81,7 @@ const FormLayout = ( { fields, gap } ) => {
               <SelectWrapper
                 { ...input }
                 { ...relationData }
+                description={ input?.description ? formatMessage( input.description ) : null }
                 isCreatingEntry={ isCreatingEntry }
                 value={ fieldValue }
               />


### PR DESCRIPTION
Adding a description to a relation input in `config/plugin.ts` results in an **error during component rendering**:

> Objects are not valid as a React child (found: object with keys {id, defaultMessage}). If you meant to render a collection of children, use an array instead.

Example of problematic config/plugin.ts:
```
export default {
  menus: {
    config: {
      maxDepth: 3,
      layouts: {
        menuItem: {
          select: [
            {
              input: {
                name: "example_relation_one",
                type: "relation",
                label: "Relation (hasOne)",
                description: "This is an example hasOne relation",
              },
            },
            {
              input: {
                name: "example_relation_many",
                type: "relation",
                label: "Relation (hasMany)",
                description: "This is an example hasMany relation",
              },
            },
          ],
        },
      },
    },
  },
};

```

This pull request aims to solve that problem.