### PR TITLE
Different translation optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ In `./config/plugins.js`, we will configure the `layouts` prop to allow our cust
 
 New tabs in the edit panel are configured with each key in the `layouts.menuItem` object. The example below will add our custom field into the "Link" tab and it will occupy the remaining 6 columns of spacing in that panel.
 
+`./config/plugin.js`
+
 ```js
 module.exports = {
   menus: {
@@ -135,6 +137,8 @@ module.exports = {
                 label: 'Custom Field Label',
                 name: 'custom_field',
                 type: 'text',
+                description: 'My fancy description',
+                placeholder: 'Some placeholder'
               },
               grid: {
                 col: 6,
@@ -146,6 +150,26 @@ module.exports = {
     },
   },
 };
+```
+
+### 3. (optional) Add translations
+The values of `label`, `placeholder` and `description` fields are used as **defaultMessages** during translation. You can easily add translations for multiple languages, for example by editing your admin plugin configuration file:
+
+`./src/admin/app.js`
+
+```js
+const config = {
+  locales: ["en"],
+  translations: {
+    en: {
+      "menus.customFields.my_custom_text.label": "Translated Label",
+      "menus.customFields.my_custom_text.placeholder": "Translated Placeholder",
+      "menus.customFields.my_custom_text.description": "Translated Description",
+    }
+  }
+};
+
+...
 ```
 
 ### Field config and grid layout
@@ -199,6 +223,7 @@ For `select` input types, the `enum` values associated with the attribute will b
   },
 ],
 ```
+The labels of `select` input options can be translated with keys like `menus.customFields.<field_name>.options.<option_value>`
 
 You may also omit the `input` prop and just add some white space with the `grid` prop.
 

--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ const config = {
   locales: ["en"],
   translations: {
     en: {
-      "menus.customFields.my_custom_text.label": "Translated Label",
-      "menus.customFields.my_custom_text.placeholder": "Translated Placeholder",
-      "menus.customFields.my_custom_text.description": "Translated Description",
+      "menus.customFields.custom_field.label": "Translated Label",
+      "menus.customFields.custom_field.placeholder": "Translated Placeholder",
+      "menus.customFields.custom_field.description": "Translated Description",
     }
   }
 };

--- a/admin/src/components/EditMenuItem/index.js
+++ b/admin/src/components/EditMenuItem/index.js
@@ -63,7 +63,7 @@ const EditMenuItem = ( { data, fields } ) => {
           { Object.keys( fields ).map( ( key, i ) => (
             <Tab variant="simple" key={ i } hasError={ hasTabError( key ) }>
               { formatMessage( {
-                id: getTrad(`edit.tabs.title.${key}`),
+                id: getTrad( `edit.tabs.title.${key}` ),
                 defaultMessage: camelToTitle( key ),
               } ) }
             </Tab>

--- a/admin/src/components/EditMenuItem/index.js
+++ b/admin/src/components/EditMenuItem/index.js
@@ -63,7 +63,7 @@ const EditMenuItem = ( { data, fields } ) => {
           { Object.keys( fields ).map( ( key, i ) => (
             <Tab variant="simple" key={ i } hasError={ hasTabError( key ) }>
               { formatMessage( {
-                id: key,
+                id: getTrad(`edit.tabs.title.${key}`),
                 defaultMessage: camelToTitle( key ),
               } ) }
             </Tab>

--- a/admin/src/components/FormLayout/index.js
+++ b/admin/src/components/FormLayout/index.js
@@ -29,9 +29,13 @@ const FormLayout = ( { fields, gap } ) => {
   const getFieldError = ( name, label ) => {
     const msg = get( errors, name, null );
 
-    // Ensure that repeatable items remove the array bracket notation from the error.
     if ( msg ) {
-      return msg.replace( name, label );
+      // Ensure that repeatable items remove the array bracket notation from the error.
+      if ( typeof msg === 'string' ) {
+        return msg.replace( name, label );
+      } else {
+        return msg;
+      }
     }
   };
 

--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -2,7 +2,7 @@ import { prefixPluginTranslations } from '@strapi/helper-plugin';
 
 import { Initializer, PluginIcon } from './components';
 import reducers from './reducers';
-import { pluginId, pluginName } from './utils';
+import { getTrad, pluginId, pluginName } from './utils';
 
 export default {
   register( app ) {
@@ -12,7 +12,7 @@ export default {
       to: `/plugins/${pluginId}`,
       icon: PluginIcon,
       intlLabel: {
-        id: 'plugin.name',
+        id: getTrad('plugin.name'),
         defaultMessage: pluginName,
       },
       Component: async () => {

--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -12,7 +12,7 @@ export default {
       to: `/plugins/${pluginId}`,
       icon: PluginIcon,
       intlLabel: {
-        id: getTrad('plugin.name'),
+        id: getTrad( 'plugin.name' ),
         defaultMessage: pluginName,
       },
       Component: async () => {

--- a/admin/src/pages/EditView/form-layout.js
+++ b/admin/src/pages/EditView/form-layout.js
@@ -78,7 +78,7 @@ const menuItem = [
         value: option,
         metadatas: {
           intlLabel: {
-            id: getTrad(`form.label.option.${option}`),
+            id: getTrad( `form.label.option.${option}` ),
             defaultMessage: option,
           },
         },

--- a/admin/src/pages/EditView/form-layout.js
+++ b/admin/src/pages/EditView/form-layout.js
@@ -78,7 +78,7 @@ const menuItem = [
         value: option,
         metadatas: {
           intlLabel: {
-            id: `form.label.option.${option}`,
+            id: getTrad(`form.label.option.${option}`),
             defaultMessage: option,
           },
         },

--- a/admin/src/pages/EditView/form-schema.js
+++ b/admin/src/pages/EditView/form-schema.js
@@ -7,17 +7,18 @@ import {
   URL_MAILTO_REGEX,
   URL_TEL_REGEX,
 } from '../../constants';
+import { getTrad } from '../../utils';
 
 const itemSchema = yup.object().shape( {
   order: yup
     .number( translatedErrors.number )
-    .required(),
+    .required( translatedErrors.required ),
   title: yup
     .string( translatedErrors.string )
-    .required(),
+    .required( translatedErrors.required ),
   url: yup
     .string( translatedErrors.string )
-    .test( value => !! (
+    .test( 'is-url', getTrad('error.url.invalid'), value => !! (
       ! value ||
       URL_ABSOLUTE_REGEX.test( value ) ||
       URL_RELATIVE_REGEX.test( value ) ||
@@ -34,11 +35,11 @@ const schema = yup.object().shape( {
   title: yup
     .string( translatedErrors.string )
     .nullable()
-    .required(),
+    .required( translatedErrors.required ),
   slug: yup
     .string( translatedErrors.string )
     .nullable()
-    .required(),
+    .required( translatedErrors.required ),
   items: yup
     .array()
     .of( itemSchema ),

--- a/admin/src/pages/EditView/form-schema.js
+++ b/admin/src/pages/EditView/form-schema.js
@@ -18,7 +18,7 @@ const itemSchema = yup.object().shape( {
     .required( translatedErrors.required ),
   url: yup
     .string( translatedErrors.string )
-    .test( 'is-url', getTrad('error.url.invalid'), value => !! (
+    .test( 'is-url', getTrad( 'error.url.invalid' ), value => !! (
       ! value ||
       URL_ABSOLUTE_REGEX.test( value ) ||
       URL_RELATIVE_REGEX.test( value ) ||

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -1,6 +1,7 @@
 {
   "plugin.name": "Menus",
 
+  "ui.add.menu": "Add submenu",
   "ui.add.menuItem": "Add menu item",
   "ui.cancel": "Cancel",
   "ui.clone": "Clone",
@@ -38,6 +39,8 @@
   "form.label.option._top": "_top",
   "form.label.slug": "Slug",
   "form.label.title": "Title",
+  "form.label.url": "URL",
+  "form.label.target": "Target",
   "form.label.items": "Items",
   "form.placeholder.untitled": "Untitled"
 }

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -44,5 +44,6 @@
   "form.label.items": "Items",
   "form.placeholder.untitled": "Untitled",
 
-  "error.slug.taken": "The slug {slug} is already taken"
+  "error.slug.taken": "The slug {slug} is already taken",
+  "error.url.invalid": "This is an invalid URL"
 }

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -45,5 +45,5 @@
   "form.placeholder.untitled": "Untitled",
 
   "error.slug.taken": "The slug {slug} is already taken",
-  "error.url.invalid": "This is an invalid URL"
+  "error.url.invalid": "This is an invalid URL format"
 }

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -42,5 +42,7 @@
   "form.label.url": "URL",
   "form.label.target": "Target",
   "form.label.items": "Items",
-  "form.placeholder.untitled": "Untitled"
+  "form.placeholder.untitled": "Untitled",
+
+  "error.slug.taken": "The slug {slug} is already taken"
 }

--- a/admin/src/utils/get-fields-layout.js
+++ b/admin/src/utils/get-fields-layout.js
@@ -1,12 +1,12 @@
 import { get, omit } from 'lodash';
 import getTrad from './get-trad';
 
-const formatString = (fieldname, context, defaultMessage) => ( {
-  id: getTrad(`customFields.${fieldname}.${context}`),
+const formatString = ( fieldname, context, defaultMessage ) => ( {
+  id: getTrad( `customFields.${fieldname}.${context}` ),
   defaultMessage: defaultMessage,
 } );
 
-const formatOption = (fieldname, option) => {
+const formatOption = ( fieldname, option ) => {
   const isString = typeof option === 'string';
   const isCustom = ! isString && !! option?.label && !! option?.value;
   let label, value;
@@ -33,7 +33,7 @@ const formatOption = (fieldname, option) => {
     value,
     metadatas: {
       intlLabel: {
-        id: getTrad(`customFields.${fieldname}.options.${value}`),
+        id: getTrad( `customFields.${fieldname}.options.${value}` ),
         defaultMessage: label,
       },
     },

--- a/admin/src/utils/get-fields-layout.js
+++ b/admin/src/utils/get-fields-layout.js
@@ -56,12 +56,10 @@ const normalizeField = ( field, schema ) => {
   // We don't want the `label` prop for the rendered input component.
   let input = omit( field.input, 'label' );
 
-  if ( label ) {
+  // Ignore label field when intlLabel is already set (default fields)
+  if( !input.intlLabel ) {
     // Replace `label` prop in custom config with formatted object.
-    input.intlLabel = formatString( name, 'label', label );
-  } else {
-    // GenericInput throws errors when intlLabel is not set
-    input.intlLabel = name;
+    input.intlLabel = formatString( name, 'label', label || name );
   }
 
   // Replace `placeholder` prop in custom config with formatted object.

--- a/admin/src/utils/get-fields-layout.js
+++ b/admin/src/utils/get-fields-layout.js
@@ -56,9 +56,12 @@ const normalizeField = ( field, schema ) => {
   // We don't want the `label` prop for the rendered input component.
   let input = omit( field.input, 'label' );
 
-  // Replace `label` prop in custom config with formatted object.
   if ( label ) {
+    // Replace `label` prop in custom config with formatted object.
     input.intlLabel = formatString( name, 'label', label );
+  } else {
+    // GenericInput throws errors when intlLabel is not set
+    input.intlLabel = name;
   }
 
   // Replace `placeholder` prop in custom config with formatted object.

--- a/admin/src/utils/get-fields-layout.js
+++ b/admin/src/utils/get-fields-layout.js
@@ -1,11 +1,12 @@
 import { get, omit } from 'lodash';
+import getTrad from './get-trad';
 
-const formatString = str => ( {
-  id: str,
-  defaultMessage: str,
+const formatString = (fieldname, context, defaultMessage) => ( {
+  id: getTrad(`customFields.${fieldname}.${context}`),
+  defaultMessage: defaultMessage,
 } );
 
-const formatOption = option => {
+const formatOption = (fieldname, option) => {
   const isString = typeof option === 'string';
   const isCustom = ! isString && !! option?.label && !! option?.value;
   let label, value;
@@ -32,7 +33,7 @@ const formatOption = option => {
     value,
     metadatas: {
       intlLabel: {
-        id: label,
+        id: getTrad(`customFields.${fieldname}.options.${value}`),
         defaultMessage: label,
       },
     },
@@ -57,22 +58,22 @@ const normalizeField = ( field, schema ) => {
 
   // Replace `label` prop in custom config with formatted object.
   if ( label ) {
-    input.intlLabel = formatString( label );
+    input.intlLabel = formatString( name, 'label', label );
   }
 
   // Replace `placeholder` prop in custom config with formatted object.
   if ( typeof placeholder === 'string' ) {
-    input.placeholder = formatString( placeholder );
+    input.placeholder = formatString( name, 'placeholder', placeholder );
   }
 
   // Replace `description` prop in custom config with formatted object.
   if ( typeof description === 'string' ) {
-    input.description = formatString( description );
+    input.description = formatString( name, 'description', description );
   }
 
   // Replace `options` props in custom config with `metadatas`, `key`, and `value` object.
   if ( type === 'select' ) {
-    input.options = options.map( formatOption );
+    input.options = options.map( option => formatOption( name, option) );
   }
 
   return {

--- a/admin/src/utils/get-fields-layout.js
+++ b/admin/src/utils/get-fields-layout.js
@@ -1,12 +1,12 @@
 import { get, omit } from 'lodash';
 import getTrad from './get-trad';
 
-const formatString = ( fieldname, context, defaultMessage ) => ( {
-  id: getTrad( `customFields.${fieldname}.${context}` ),
+const formatString = ( name, context, defaultMessage ) => ( {
+  id: getTrad( `customFields.${name}.${context}` ),
   defaultMessage: defaultMessage,
 } );
 
-const formatOption = ( fieldname, option ) => {
+const formatOption = ( name, option ) => {
   const isString = typeof option === 'string';
   const isCustom = ! isString && !! option?.label && !! option?.value;
   let label, value;
@@ -33,7 +33,7 @@ const formatOption = ( fieldname, option ) => {
     value,
     metadatas: {
       intlLabel: {
-        id: getTrad( `customFields.${fieldname}.options.${value}` ),
+        id: getTrad( `customFields.${name}.options.${value}` ),
         defaultMessage: label,
       },
     },
@@ -57,9 +57,9 @@ const normalizeField = ( field, schema ) => {
   let input = omit( field.input, 'label' );
 
   // Ignore label field when intlLabel is already set (default fields)
-  if( !input.intlLabel ) {
+  if( ! input.intlLabel ) {
     // Replace `label` prop in custom config with formatted object.
-    input.intlLabel = formatString( name, 'label', label || name );
+    input.intlLabel = formatString( name, 'label', label ?? name );
   }
 
   // Replace `placeholder` prop in custom config with formatted object.

--- a/server/controllers/menu.js
+++ b/server/controllers/menu.js
@@ -123,7 +123,11 @@ module.exports = createCoreController( UID_MENU, ( { strapi } ) =>  ( {
 
     if ( ! isAvailable ) {
       const errorMessage = `The slug ${data.slug} is already taken`;
-      return ctx.badRequest( errorMessage, { slug: errorMessage } );
+      return ctx.badRequest( errorMessage, { slug: {
+        id: 'menus.error.slug.taken',
+        defaultMessage: errorMessage,
+        values: { slug: data.slug }
+      } } );
     }
 
     // Set vars related to nesting data.
@@ -163,7 +167,11 @@ module.exports = createCoreController( UID_MENU, ( { strapi } ) =>  ( {
 
     if ( ! isAvailable ) {
       const errorMessage = `The slug ${data.slug} is already taken`;
-      return ctx.badRequest( errorMessage, { slug: errorMessage } );
+      return ctx.badRequest( errorMessage, { slug: {
+        id: 'menus.error.slug.taken',
+        defaultMessage: errorMessage,
+        values: { slug: data.slug }
+      } } );
     }
 
     // Set vars related to nesting data.

--- a/server/controllers/menu.js
+++ b/server/controllers/menu.js
@@ -126,7 +126,7 @@ module.exports = createCoreController( UID_MENU, ( { strapi } ) =>  ( {
       return ctx.badRequest( errorMessage, { slug: {
         id: 'menus.error.slug.taken',
         defaultMessage: errorMessage,
-        values: { slug: data.slug }
+        values: { slug: data.slug },
       } } );
     }
 
@@ -170,7 +170,7 @@ module.exports = createCoreController( UID_MENU, ( { strapi } ) =>  ( {
       return ctx.badRequest( errorMessage, { slug: {
         id: 'menus.error.slug.taken',
         defaultMessage: errorMessage,
-        values: { slug: data.slug }
+        values: { slug: data.slug },
       } } );
     }
 


### PR DESCRIPTION
As written in the title:

### Fixes
- Added some missing `getTrad(...)` calls to prefix the translation keys
- Added missing english translation entries that are used in the code (`ui.add.menu`, `form.label.url`, `form.label.target`)
- Avoid error when `input.label` is empty ([GenericInput needs a non-null intlLabel](https://github.com/strapi/strapi/blob/ee00599cd73180e84df84536521183b48892a28c/packages/core/helper-plugin/lib/src/components/GenericInput/index.js#L107))

### Features
- Added validation error message keys to `admin/src/pages/EditView/form-schema.js`
- API returns an object when slug validation fails - that allows easy translation of this message
- Enabled translation of custom fields with `menu.customFields.<field_name>.<label/placeholder/description>`
- Enabled translation of custom field obtions with `menu.customFields.<field_name>.options.<option_value>`