### PR TITLE
Fix issue with refetching menu list

### DIFF
--- a/admin/src/pages/IndexView/index.js
+++ b/admin/src/pages/IndexView/index.js
@@ -59,7 +59,9 @@ const IndexView = ( { history } ) => {
     },
   } );
 
-  useEffect( () => refetch(), [ page, pageSize ] );
+  useEffect( () => {
+    refetch()
+  }, [ page, pageSize ] );
 
   const deleteMutation = useMutation( id => api.deleteAction( id ), {
     onSuccess: async () => {


### PR DESCRIPTION
This PR fixes the issue where Menus plugin breaks admin panel. Navigating to Menus and then to some other part of admin panel renders a blank page, running with `yarn develop --watch-admin` hints that `destroy` function does not which is usually caused by incorrect use of `useEffect` where hook does not return cleanup function.