### PR TITLE
Lazy custom fields

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -34,5 +34,6 @@ As Strapi updates, these components and files may also need to be updated in thi
 | 17 | RelationInputDataManager | RelationInputDataManager.js | To maintain proper dirty state for relation fields, we need to omit the `label` and `id` props that come from the `ReactSelect` component. |
 | 18 | RelationInputDataManager<br>RelationInputDataManager | RelationInputDataManager.js<br>useRelation.js | Avoid re-fetching relation data as fields are toggled in the UI with `hasLoaded` var. Some cloned vars are also removed because of how this is already handled in the plugin. |
 | 19 | RelationInput | components/RelationItem.js | This plugin has no need to work with different item types like dynamic zones or components. |
+| 20 | useLazyComponents | hooks/use-lazy-components.js | This hook was cloned from Strapi core to help render custom fields. |
 
 Look for `CUSTOM MOD [n]` comments to identify exactly what lines were changed. The number in the comment corresponds to the table above.

--- a/admin/src/hooks/index.js
+++ b/admin/src/hooks/index.js
@@ -1,4 +1,4 @@
-export { default as useLazyComponents } from './use-lazy-components';
+export { default as useLazyComponents } from './use-lazy-components'; // CUSTOM MOD [20].
 export { default as useMenuData } from './use-menu-data';
 export { default as usePluginConfig } from './use-plugin-config';
 export { default as useStickyPosition } from './use-sticky-position';

--- a/admin/src/hooks/index.js
+++ b/admin/src/hooks/index.js
@@ -1,3 +1,4 @@
+export { default as useLazyComponents } from './use-lazy-components';
 export { default as useMenuData } from './use-menu-data';
 export { default as usePluginConfig } from './use-plugin-config';
 export { default as useStickyPosition } from './use-sticky-position';

--- a/admin/src/hooks/use-lazy-components.js
+++ b/admin/src/hooks/use-lazy-components.js
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useCustomFields } from '@strapi/helper-plugin';
+
+const componentStore = new Map();
+
+/**
+ * @description
+ * A hook to lazy load custom field components
+ * @param {Array.<string>} componentUids - The uids to look up components
+ * @returns object
+ */
+const useLazyComponents = (componentUids = []) => {
+  const [lazyComponentStore, setLazyComponentStore] = useState(Object.fromEntries(componentStore));
+  /**
+   * Start loading only if there are any components passed in
+   * and there are some new to load
+   */
+  const newUids = componentUids.filter((uid) => !componentStore.get(uid));
+  const [loading, setLoading] = useState(() => !!newUids.length);
+  const customFieldsRegistry = useCustomFields();
+
+  useEffect(() => {
+    const setStore = (store) => {
+      setLazyComponentStore(store);
+      setLoading(false);
+    };
+
+    const lazyLoadComponents = async (uids, components) => {
+      const modules = await Promise.all(components);
+
+      uids.forEach((uid, index) => {
+        componentStore.set(uid, modules[index].default);
+      });
+
+      setStore(Object.fromEntries(componentStore));
+    };
+
+    if (newUids.length > 0) {
+      setLoading(true);
+
+      const componentPromises = newUids.reduce((arrayOfPromises, uid) => {
+        const customField = customFieldsRegistry.get(uid);
+
+        if (customField) {
+          arrayOfPromises.push(customField.components.Input());
+        }
+
+        return arrayOfPromises;
+      }, []);
+
+      if (componentPromises.length > 0) {
+        lazyLoadComponents(newUids, componentPromises);
+      }
+    }
+  }, [newUids, customFieldsRegistry]);
+
+  /**
+   * Wrap this in a callback so it can be used in
+   * effects to cleanup the cached store if required
+   */
+  const cleanup = useCallback(() => {
+    componentStore.clear();
+    setLazyComponentStore({});
+  }, []);
+
+  return { isLazyLoading: loading, lazyComponentStore, cleanup };
+};
+
+export default useLazyComponents;


### PR DESCRIPTION
Fixes an issue with using custom fields in menu items. A `useLazyComponents` hook was cloned from Strapi core and implemented into this plugin's `FormLayout` component.