### PR TITLE
Fixed bug with relationsinput description

### DIFF
--- a/admin/src/coreComponents/RelationInputDataManager/RelationInputDataManager.js
+++ b/admin/src/coreComponents/RelationInputDataManager/RelationInputDataManager.js
@@ -305,7 +305,10 @@ export const RelationInputDataManager = ({
     <RelationInput
       error={error}
       canReorder={!toOneRelation}
-      description={description}
+      description={formatMessage({
+        defaultMessage: description.defaultMessage,
+        id: description.id,
+      })}
       disabled={isDisabled}
       iconButtonAriaLabel={formatMessage({
         id: 'content-manager.components.RelationInput.icon-button-aria-label', // CUSTOM MOD [4].
@@ -406,7 +409,11 @@ RelationInputDataManager.propTypes = {
   // entityId: PropTypes.number, // CUSTOM MOD [9].
   editable: PropTypes.bool,
   error: PropTypes.string,
-  description: PropTypes.string,
+  description: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    defaultMessage: PropTypes.string.isRequired,
+    values: PropTypes.object,
+  }).isRequired,
   intlLabel: PropTypes.shape({
     id: PropTypes.string.isRequired,
     defaultMessage: PropTypes.string.isRequired,


### PR DESCRIPTION
RelationInputDataManager was trying to render an IntlLabel as if it were a string, for whatever reason. When adding custom relation fields to the plugin, any generated description would be rendered as an object, causing a crash.

This commit changes the require prop type to an intl label, as well as formats the intlLable instead of trying to pass it directly to the component.